### PR TITLE
fix: Audio playing in background after exiting from player widget

### DIFF
--- a/ios/Classes/NativePlayerView.swift
+++ b/ios/Classes/NativePlayerView.swift
@@ -5,6 +5,7 @@ import TPStreamsSDK
 class NativePlayerView: NSObject, FlutterPlatformView {
     var player: TPAVPlayer!
     var playerViewController: TPStreamPlayerViewController?
+    var methodChannel: FlutterMethodChannel
 
     func view() -> UIView {
         return playerViewController?.view ?? UIView()
@@ -16,6 +17,23 @@ class NativePlayerView: NSObject, FlutterPlatformView {
             playerViewController = TPStreamPlayerViewController()
             playerViewController!.player = player
         }
+        methodChannel = FlutterMethodChannel(name: "tpstreams_player_sdk/player_view_\(viewId)", binaryMessenger: messenger)
         super.init()
+        methodChannel.setMethodCallHandler(onMethodCall)
+        
+    }
+    
+    func onMethodCall(call: FlutterMethodCall, result: FlutterResult) {
+        switch(call.method){
+        case "dispose":
+            self.dispose()
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+    
+    func dispose(){
+        self.player?.replaceCurrentItem(with: nil)
+        self.player = nil
     }
 }

--- a/lib/tpstreams_player.dart
+++ b/lib/tpstreams_player.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 
 import 'package:flutter/gestures.dart';
@@ -5,7 +7,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-class TPStreamPlayer extends StatelessWidget {
+class TPStreamPlayer extends StatefulWidget {
   final String assetId;
   final String accessToken;
   final double aspectRatio;
@@ -18,19 +20,26 @@ class TPStreamPlayer extends StatelessWidget {
   }) : super(key: key);
 
   @override
+  State<TPStreamPlayer> createState() => _TPStreamPlayerState();
+}
+
+class _TPStreamPlayerState extends State<TPStreamPlayer> {
+  MethodChannel? methodChannel;
+
+  @override
   Widget build(BuildContext context) {
     return SafeArea(
         child: Container(
           color: Colors.black,
           child: AspectRatio(
-            aspectRatio: aspectRatio, 
+            aspectRatio: widget.aspectRatio, 
             child: getPlayerNativeView()
           ),
     ));
   }
 
   Widget getPlayerNativeView() {
-    var creationParams = {"assetId": assetId, "accessToken": accessToken};
+    var creationParams = {"assetId": widget.assetId, "accessToken": widget.accessToken};
 
     switch (defaultTargetPlatform) {
       
@@ -59,10 +68,23 @@ class TPStreamPlayer extends StatelessWidget {
             viewType: 'tpstreams_player_sdk/player_view',
             creationParams: creationParams,
             creationParamsCodec: const StandardMessageCodec(),
+            onPlatformViewCreated: onIOSPlatformViewCreated,
           );
       default:
         return Text(
             '$defaultTargetPlatform is not yet supported by the web_view plugin');
+    }
+  }
+
+  onIOSPlatformViewCreated(int id) {
+    methodChannel = MethodChannel('tpstreams_player_sdk/player_view_$id');
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    if (Platform.isIOS) {
+      methodChannel?.invokeMethod("dispose");
     }
   }
 }


### PR DESCRIPTION
- Background audio continues to play even after exiting the player widget due to the AVPlayer not being cleared on widget disposal. 
- To address this, we're using the Flutter method Channel to clear the AVPlayer when the widget is disposed and we're using method channel because Flutter does not provide the dispose callback method for iOS platform views like providing for Android. 
- Ref: https://github.com/flutter/flutter/issues/27240